### PR TITLE
Update ValidatorAssistant.php

### DIFF
--- a/src/ValidatorAssistant.php
+++ b/src/ValidatorAssistant.php
@@ -1,6 +1,6 @@
 <?php namespace Fadion\ValidatorAssistant;
 
-use Illuminate\Validation\Validator;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\App;
 


### PR DESCRIPTION
fix PHP Fatal error:  Call to undefined method Illuminate\Validation\Validator::extend() in /var/www/soc2/vendor/fadion/validator-assistant/src/ValidatorAssistant.php on line 359