### PR TITLE
Fixed the apply method to allow colons in argument

### DIFF
--- a/src/Filters.php
+++ b/src/Filters.php
@@ -37,20 +37,23 @@ class Filters {
 
         if (count($filters)) {
             foreach ($filters as $name => $filter) {
-                $rules = explode('|', $filter);
+                
+                // Allow filter to defined as array or pipe delimited string
+                $rules = ( is_array($filter) ) ? $filter : explode('|', $filter);
 
                 // At least a rule is set and the input
                 // field exists.
                 if (count($rules) and isset($inputs[$name])) {
                     foreach ($rules as $rule) {
-                        $rule = explode(':', $rule);
+                        $splitAt = strpos($rule, ':');
 
                         $argument = null;
-                        if (isset($rule[1])) {
-                            $argument = $rule[1];
+                        if ( $splitAt ) {
+                            $argument = substr($rule, $splitAt+1);
+                            $rule     = substr($rule, 0, $splitAt);
                         }
 
-                        $rule = strtolower($rule[0]);
+                        $rule = strtolower($rule);
                         $rule = str_replace('_', ' ', $rule);
                         $rule = str_replace(' ', '', ucwords($rule));
 


### PR DESCRIPTION
I came across a problem where I wanted to use filters to format a datetime string to the format of "2015-01-01 12:30:45", however the filter apply method explodes the string using the colon, breaking the format. 

I changed the code to only split at the first occurence of a colon, and also to allow for filter rules to be defined as an array instead of a pipe delimited string (consistent with laravel's validation rules syntax)