### PR TITLE
Added ability to define custom filters within ValidatorAssistant child classes

### DIFF
--- a/src/Filters.php
+++ b/src/Filters.php
@@ -28,8 +28,8 @@ class Filters {
     */
     public function __construct($inputs, $filters, $assistant = null)
     {
-        $this->inputs = $inputs;
-        $this->filters = $filters;
+        $this->inputs    = $inputs;
+        $this->filters   = $filters;
         $this->assistant = $assistant;
     }
 
@@ -40,8 +40,9 @@ class Filters {
     */
     public function apply()
     {
-        $filters = $this->filters;
-        $inputs = $this->inputs;
+        $filters   = $this->filters;
+        $inputs    = $this->inputs;
+        $assistant = $this->assistant;
 
         if (count($filters)) {
             foreach ($filters as $name => $filter) {

--- a/src/Filters.php
+++ b/src/Filters.php
@@ -7,6 +7,13 @@ class Filters {
     */
     protected $filters = array();
 
+
+    /**
+     * The ValidatorAssistant object
+     * @var null
+     */
+    protected $assistant = null;
+
     /**
     * @var mixed Inputs
     */
@@ -19,10 +26,11 @@ class Filters {
     * @param  string  $filters
     * @return void
     */
-    public function __construct($inputs, $filters)
+    public function __construct($inputs, $filters, $assistant = null)
     {
         $this->inputs = $inputs;
         $this->filters = $filters;
+        $this->assistant = $assistant;
     }
 
     /**
@@ -62,6 +70,11 @@ class Filters {
                         // Check if rule is defined as a class method.
                         if (method_exists($this, $method)) {
                             $inputs[$name] = $this->$method($inputs[$name], $argument);
+                        }
+
+                        // Check if ValidatorAssistant object has the same/custom filter defined
+                        if ( $assistant && method_exists($assistant, $method)) {
+                            $inputs[$name] = $assistant->$method($inputs[$name], $argument);
                         }
                     }
                 }

--- a/src/ValidatorAssistant.php
+++ b/src/ValidatorAssistant.php
@@ -4,10 +4,6 @@ use Illuminate\Validation\Validator;
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\App;
 
-use Symfony\Component\HttpFoundation\File\File;
-use Symfony\Component\Translation\TranslatorInterface;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
-
 abstract class ValidatorAssistant {
 
     /**

--- a/src/ValidatorAssistant.php
+++ b/src/ValidatorAssistant.php
@@ -4,6 +4,10 @@ use Illuminate\Validation\Validator;
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\App;
 
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
 abstract class ValidatorAssistant {
 
     /**
@@ -124,7 +128,7 @@ abstract class ValidatorAssistant {
         $this->resolveSubrules();
 
         // Apply input filters.
-        $filters = new Filters($this->inputs, $this->filters);
+        $filters = new Filters($this->inputs, $this->filters, $this);
         $this->inputs = $filters->apply();
 
         // Apply custom rules.

--- a/src/ValidatorAssistant.php
+++ b/src/ValidatorAssistant.php
@@ -4,6 +4,10 @@ use Illuminate\Validation\Validator;
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\App;
 
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
 abstract class ValidatorAssistant {
 
     /**
@@ -222,9 +226,21 @@ abstract class ValidatorAssistant {
     */
     public function scope($scope)
     {
+        $beforeMethod = 'before'.ucfirst($scope);
+        $afterMethod  = 'after'.ucfirst($scope);
+        if ( method_exists($this, $beforeMethod) )
+        {
+            call_user_func([$this,$beforeMethod]);
+        }
         $this->rules = $this->resolveScope($scope);
         $this->attributes = $this->resolveAttributes($scope);
         $this->messages = $this->resolveMessages($scope);
+
+
+        if ( method_exists($this, $afterMethod) )
+        {
+            call_user_func([$this,$afterMethod]);
+        }
 
         return $this;
     }


### PR DESCRIPTION
This is a quick and simple hack to add the ability to define custom filters in the validator assistant classes. 

*Example definition*
```
class SomeValidator extends ValidatorAssistant {
    protected $filters = [
        'inputField' => 'customFilter'
    ];

    public function filterCustomFilter($value, $argument = null) {
        return some_custom_filter_function($value);
    }
}
```
